### PR TITLE
Update how random bytes are turned into integer

### DIFF
--- a/lib/mix/tasks/optimushash.seed.ex
+++ b/lib/mix/tasks/optimushash.seed.ex
@@ -77,9 +77,7 @@ defmodule Mix.Tasks.OptimusHash.Seed do
 
         random =
           :crypto.strong_rand_bytes(max_size)
-          |> Base.encode16()
-          |> Integer.parse(16)
-          |> elem(0)
+          |> :binary.decode_unsigned
           |> band(max_id)
 
         OptimusHash.new(


### PR DESCRIPTION
Tiny update, but `:binary.decode_unsigned/1` is a pre-existing erlang function for turning a binary into an integer. Produces the same output.

Secondary question: should `:crypto.strong_rand_bytes(max_size)` be using `ceil(max_size / 8)`? It's currently generating max_size * 8 bits, so it seems like a bunch of the beginning bits are useless because max_size is so much smaller and they get lost when `band`ed. I might just not totally understand what's going on though. 